### PR TITLE
Sprockets 3 support

### DIFF
--- a/lib/js_asset_paths/generator.rb
+++ b/lib/js_asset_paths/generator.rb
@@ -8,11 +8,14 @@ module JsAssetPaths
 
     private
 
+    # Note: In sprockets 2, `each_file` yields a `Pathname`. In 3,
+    # it yields a string. This method supports both.
     def self.asset_hash
       assets.each_file.each_with_object({}) do |filepath, memo|
-        relative_path = filepath.relative_path_from(base_asset_path)
+        path = ::Pathname.new(filepath.to_s)
+        relative_path = path.relative_path_from(base_asset_path)
 
-        memo[relative_path] = output_path(filepath) if local?(relative_path)
+        memo[relative_path] = output_path(path) if local?(relative_path)
       end
     end
 


### PR DESCRIPTION
It seems that `each_file` used to yield `Pathname`s, now yields strings?

I didn't research this very thoroughly, this just seemed like the simplest fix.

There's probably a better way that preserves compat. w/ sprockets 2.
